### PR TITLE
Fix-zero-dollar-line-items

### DIFF
--- a/admin/create-estimate.php
+++ b/admin/create-estimate.php
@@ -72,7 +72,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Validate each line item
                 $validatedDescription = validateAndSanitizeString($description, 500, "Item {$index} description", true);
                 $validatedQuantity = validateCurrency($_POST['item_quantity'][$index] ?? '', "Item {$index} quantity", true);
-                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true);
+                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true, true);
                 
                 $lineTotal = $validatedQuantity * $validatedUnitPrice;
                 $subtotal += $lineTotal;

--- a/admin/create-invoice.php
+++ b/admin/create-invoice.php
@@ -70,7 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Validate each line item
                 $validatedDescription = validateAndSanitizeString($description, 500, "Item {$index} description", true);
                 $validatedQuantity = validateCurrency($_POST['item_quantity'][$index] ?? '', "Item {$index} quantity", true);
-                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true);
+                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true, true);
                 
                 $lineTotal = $validatedQuantity * $validatedUnitPrice;
                 $subtotal += $lineTotal;

--- a/admin/edit-estimate.php
+++ b/admin/edit-estimate.php
@@ -68,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Validate each line item
                 $validatedDescription = validateAndSanitizeString($description, 500, "Item {$index} description", true);
                 $validatedQuantity = validateCurrency($_POST['item_quantity'][$index] ?? '', "Item {$index} quantity", true);
-                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true);
+                $validatedUnitPrice = validateCurrency($_POST['item_price'][$index] ?? '', "Item {$index} price", true, true);
                 
                 $lineTotal = $validatedQuantity * $validatedUnitPrice;
                 $subtotal += $lineTotal;

--- a/admin/edit-invoice.php
+++ b/admin/edit-invoice.php
@@ -116,7 +116,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Add new line items
         if (!empty($_POST['line_items'])) {
             foreach ($_POST['line_items'] as $item) {
-                if (!empty($item['description']) && !empty($item['quantity']) && !empty($item['unit_price'])) {
+                if (!empty($item['description']) && !empty($item['quantity']) && isset($item['unit_price']) && is_numeric($item['unit_price'])) {
                     $stmt = $pdo->prepare("
                         INSERT INTO invoice_items (invoice_id, description, quantity, unit_price, total) 
                         VALUES (?, ?, ?, ?, ?)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -844,11 +844,11 @@ function validatePhone($phone, $fieldName = 'Phone', $required = false) {
 function validateCurrency($amount, $fieldName = 'Amount', $required = true, $allowZero = false) {
     $amount = trim($amount);
     
-    if ($required && empty($amount)) {
+    if ($required && ($amount === '' || $amount === null)) {
         throw new InvalidArgumentException("{$fieldName} is required.");
     }
     
-    if (!empty($amount)) {
+    if ($amount !== '' && $amount !== null) {
         if (!is_numeric($amount)) {
             throw new InvalidArgumentException("{$fieldName} must be a valid number.");
         }


### PR DESCRIPTION
The empty() check was treating "0" as empty, preventing zero-dollar line items.
Changed to explicitly check for empty string or null instead.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>